### PR TITLE
Import `pyiron_potentialfit` explicitly

### DIFF
--- a/03_fitting_and_validation/tutorial.ipynb
+++ b/03_fitting_and_validation/tutorial.ipynb
@@ -34,6 +34,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import pyiron_potentialfit\n",
     "from pyiron import Project\n",
     "from collections import Counter\n",
     "import pandas as pd\n",


### PR DESCRIPTION
In the [third notebook](https://github.com/pyiron-workshop/DPG-tutorial-2024/blob/main/03_fitting_and_validation/tutorial.ipynb) `pyiron_potentialfit` is never imported while specific job types like `PacemakerJob` used. It works because it loads a `TrainingContainer` job in the beginning which implicitly imports `pyiron_potentialfit`. But when users try to create their own fits by modifying this example they get an error message saying `pyiron_potentialfit` is not available. So I recommend to import it explicitly. 